### PR TITLE
Add host configuration to WSGIServer & rename request body parameter

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,5 +83,5 @@ if __name__ == '__main__':
     # app.run(port=5002, debug=True)
 
     # Serve the app with gevent
-    http_server = WSGIServer(('', 5000), app)
+    http_server = WSGIServer(('0.0.0.0', 5000), app)
     http_server.serve_forever()

--- a/app.py
+++ b/app.py
@@ -60,7 +60,7 @@ def index():
 def upload():
     if request.method == 'POST':
         # Get the file from post request
-        f = request.files['file']
+        f = request.files['image']
 
         # Save the file to ./uploads
         basepath = os.path.dirname(__file__)

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
         <label for="imageUpload" class="upload-label">
             Choose...
         </label>
-        <input type="file" name="file" id="imageUpload" accept=".png, .jpg, .jpeg">
+        <input type="file" name="image" id="imageUpload" accept=".png, .jpg, .jpeg">
     </form>
 
     <div class="image-section" style="display:none;">


### PR DESCRIPTION
Firefox can't resolve "http://localhost:5000" if the host parameter "0.0.0.0" is not given (Chrome was not affected.)

I also suggest renaming the request parameter "file" to "image" since the file actually IS an image. This change also makes this wonderful example application consistent with the Keras + Flask guide [Building a simple Keras + deep learning REST API](https://blog.keras.io/building-a-simple-keras-deep-learning-rest-api.html) (the parameter is called "image").

I would also like to use this opportunity to sincerly thank you for creating this example. Your effort helped me tremendously. **Thank you!**