### PR TITLE
feat(docker): install dependencies from requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:2.7.16-slim-stretch
 COPY . /usr/src/app
 WORKDIR /usr/src/app
 
-RUN pip install Werkzeug Flask numpy Keras gevent pillow h5py tensorflow
+RUN pip install -r requirements.txt
 
 
 EXPOSE 5000


### PR DESCRIPTION
there are two sources for pip now, one is the requirements.txt and another is the dockerfile, their contents are same and we should use one coherent dependence file in a project.